### PR TITLE
IMPB-1516  Version 11.8 of Jetpack is breaking sites using equity framework

### DIFF
--- a/lib/idx/class.Equity_Idx_Api.inc.php
+++ b/lib/idx/class.Equity_Idx_Api.inc.php
@@ -49,7 +49,7 @@ class Equity_Idx_Api {
 			if ( isset( $custom_equity_domain['equity_idx_domain'] ) ) {
 				$domain = $custom_equity_domain['equity_idx_domain'];
 			} elseif ( has_filter( 'equity_idx_api_domain' ) ) {
-				$domain = apply_filters( 'equity_idx_api_domain', $domain );
+				$domain = apply_filters( 'equity_idx_api_domain', $domain, null );
 			}
 
 			$headers = array_merge( $headers,
@@ -64,10 +64,10 @@ class Equity_Idx_Api {
 			'https://api.idxbroker.com/' . $level . '/' . $method,
 			array(
 				'method' => $http_method,
-				'timeout' => apply_filters( 'http_request_timeout', 180 ),
-				'redirection' => apply_filters( 'http_request_redirection_count', 5 ),
-				'httpversion' => apply_filters( 'http_request_version', '1.1' ),
-				'user-agent' => apply_filters( 'http_headers_useragent', 'WordPress/' . $wp_version . '; ' . get_bloginfo( 'url' ) ),
+				'timeout' => apply_filters( 'http_request_timeout', 180, null ),
+				'redirection' => apply_filters( 'http_request_redirection_count', 5, null ),
+				'httpversion' => apply_filters( 'http_request_version', '1.1', null ),
+				'user-agent' => apply_filters( 'http_headers_useragent', 'WordPress/' . $wp_version . '; ' . get_bloginfo( 'url' ), null ),
 				'blocking' => true,
 				'headers' => $headers,
 				'cookies' => array(),


### PR DESCRIPTION
The apply_filters() function used by WordPress has three mandatory arguments. This normally isn't an issue, but Jetpack 11.8+ appears to add a callback function to the 'http_request_timeout' hook named jetpack_oembed_timeout_override. When class.Equity_Idx_Api.inc.php calls the hook on line 67 in public function remote_get, it results in an error like the following: 

```[16-Mar-2023 07:35:08] WARNING: child 78 said into stderr: "NOTICE: PHP message: PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function jetpack_oembed_timeout_override(), 1 passed in /wordpress/wp-includes/class-wp-hook.php on line 308 and exactly 2 expected in /www/wp-content/plugins/jetpack/modules/shortcodes/others.php:29"
[16-Mar-2023 07:35:08] WARNING: child 78 said into stderr: "Stack trace:"
[16-Mar-2023 07:35:08] WARNING: child 78 said into stderr: "#0 /wordpress/wp-includes/class-wp-hook.php(308): jetpack_oembed_timeout_override(180)"
[16-Mar-2023 07:35:08] WARNING: child 78 said into stderr: "#1 /wordpress/wp-includes/plugin.php(205): WP_Hook->apply_filters(180, Array)"
[16-Mar-2023 07:35:08] WARNING: child 78 said into stderr: "#2 /www/wp-content/themes/equity/lib/idx/class.Equity_Idx_Api.inc.php(67): apply_filters('http_request_ti...', 180)"
[16-Mar-2023 07:35:08] WARNING: child 78 said into stderr: "#3 /www/wp-content/themes/equity/lib/idx/class.Equity_Idx_Api.inc.php(96): Equity_Idx_Api->remote_get('clients', 'systemlinks')"
[16-Mar-2023 07:35:08] WARNING: child 78 said into stderr: "#4 /www/wp-content/themes/equity/lib/idx/class.Equity_Idx_Api.inc.php(277): Equity_Idx_Api->decoded_response_body('clients', 'systemlinks')"
[16-Mar-2023 07:35:08] WARNING: child 78 said into stderr: "#5 /www/wp-content/themes/equity/lib/idx/class.Equity_Idx_Api.inc.php(291): Equity_Idx_Api->system_links()"
[16-Mar-2023 07:35:08] WARNING: child 78 said into stderr: "#6 /www/wp-content/themes/equity/lib/idx/class.Equity_Quicksea..."``` 

This PR adds a third `null` argument to apply_filters calls within class.Equity_Idx_Api.inc.php to avoid causing an error with Jetpack's callback. 

When testing this PR with an install of Jetpack, note that sometimes the error will not appear right away if Jetpack is recently reactivated... I'm not exactly sure what causes that behavior, but when testing on an affected or test site I'd recommend allowing fifteen minutes or more to pass. 